### PR TITLE
Fix figure template attribute typo

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -22,7 +22,7 @@
       {% if include.min-width %}min-width="{{ include.min-width }}"{% endif %} 
       {% if include.min-height %}min-height="{{ include.min-height }}"{% endif %} 
       {% if include.max-width %}max-width="{{ include.max-width }}"{% endif %} 
-      {% if include.max-height %}height="{{ include.max-height }}"{% endif %} 
+      {% if include.max-height %}max-height="{{ include.max-height }}"{% endif %}
       {% if include.alt %}alt="{{ include.alt }}"{% endif %} 
       {% if include.title %}title="{{ include.title }}"{% endif %} 
       {% if include.zoomable %}data-zoomable{% endif %}


### PR DESCRIPTION
## Summary
- correct the attribute for `max-height` in `_includes/figure.html`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685515ee8c148330a34f40af01735909